### PR TITLE
fix: correct checking of parameters

### DIFF
--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -51,18 +51,18 @@ def call(Map pipelineParams = [:]) {
         // Check sonar configuration is set and valid
         assert pipelineParams.sonar
         assert pipelineParams.sonar.enable instanceof Boolean
-        assert pipelineParams.sonar.projectKey instanceof String
-        assert pipelineParams.sonar.tokenId instanceof String
-        assert pipelineParams.sonar.exclusions instanceof String
 
         // If sonar is enabled, ensure required fields are not empty
         if (pipelineParams.sonar.enable) {
+            assert pipelineParams.sonar.projectKey instanceof String
+            assert pipelineParams.sonar.tokenId instanceof String
             assert !pipelineParams.sonar.projectKey.isEmpty() : "sonar.projectKey cannot be empty when sonar is enabled"
             assert !pipelineParams.sonar.tokenId.isEmpty() : "sonar.tokenId cannot be empty when sonar is enabled"
 
             // Validate that projectKey contains only safe characters
             assert pipelineParams.sonar.projectKey.matches(/^[a-zA-Z0-9_-]+$/) : "sonar.projectKey contains invalid characters. Only alphanumeric, underscores and hyphens are allowed"
             // Validate that exclusions don't contain potentially dangerous characters
+            assert pipelineParams.sonar.exclusions instanceof String
             assert !pipelineParams.sonar.exclusions.matches(/.*[;&|`$(){}\[\]\"].*/) : "sonar.exclusions contains potentially dangerous characters"
         }
     }


### PR DESCRIPTION
When Sonar is disabled the other parameters shouldn't be specified.

https://ci.eclipse.org/kura/job/kura-base/job/kura-bluetooth/job/PR-3/1/ fails due to an incorrect parameter validation.