### PR TITLE
feat: upload DEP packages on Kura APT repository

### DIFF
--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -130,19 +130,19 @@ def call(Map pipelineParams = [:]) {
                 maven: pipelineParams.toolchain.maven,
                 options: [artifactsPublisher(disabled: true)]
             ) {
-                repoDistribution = sh(script: '''
+                repoDistribution = sh(script: """
                     mvn -f workdir/distrib/pom.xml \
-                        -Dexec.executable=echo \
-                        -Dexec.args=\"${kura.repo.distribution}\" \
-                        -q exec:exec --non-recursive
-                ''', returnStdout: true).trim()
+                    help:evaluate \
+                    -Dexpression=kura.repo.distribution \
+                    -q -DforceStdout
+                """, returnStdout: true).trim()
 
-                repoModule = sh(script: '''
+                repoModule = sh(script: """
                     mvn -f workdir/distrib/pom.xml \
-                    -Dexec.executable=echo \
-                    -Dexec.args=\"${kura.repo.module}\" \
-                    -q exec:exec --non-recursive
-                ''', returnStdout: true).trim()
+                    help:evaluate \
+                    -Dexpression=kura.repo.module \
+                    -q -DforceStdout
+                """, returnStdout: true).trim()
             }
 
             uploadPackages(repoDistribution, repoModule)

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -118,8 +118,7 @@ def call(Map pipelineParams = [:]) {
     stage ("Deploy on Nexus Repository") {
         // Call uploadPackages only if we are on the default branch,
         // if we have DEB packages to upload and if the user has set the pushArtifacts parameter to true
-        // if (env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
-        if (true) { // FIXME: For testing only
+        if (env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
             echo "Uploading DEB packages..."
 
             def distribPom = readMavenPom file: 'workdir/distrib/pom.xml'

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -135,14 +135,14 @@ def call(Map pipelineParams = [:]) {
                     help:evaluate \
                     -Dexpression=kura.repo.distribution \
                     -q -DforceStdout
-                """, returnStdout: true).trim().get(lines.size()-1)
+                """, returnStdout: true).trim().readLines()[-1]
 
                 repoModule = sh(script: """
                     mvn -f workdir/distrib/pom.xml \
                     help:evaluate \
                     -Dexpression=kura.repo.module \
                     -q -DforceStdout
-                """, returnStdout: true).trim().get(lines.size()-1)
+                """, returnStdout: true).trim().readLines()[-1]
             }
 
             uploadPackages(repoDistribution, repoModule)

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -133,8 +133,8 @@ def call(Map pipelineParams = [:]) {
                 maven: pipelineParams.toolchain.maven,
                 options: [artifactsPublisher(disabled: true)]
             ) {
-                repoDistribution = sh(script: "mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args='${kura.repo.distribution}' -q exec:exec --non-recursive", returnStdout: true).trim()
-                repoModule = sh(script: "mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args='${kura.repo.module}' -q exec:exec --non-recursive", returnStdout: true).trim()
+                repoDistribution = sh(script: 'mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args="${kura.repo.distribution}" -q exec:exec --non-recursive', returnStdout: true).trim()
+                repoModule = sh(script: 'mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args="${kura.repo.module}" -q exec:exec --non-recursive', returnStdout: true).trim()
             }
 
             uploadPackages(repoDistribution, repoModule)

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -122,7 +122,7 @@ def call(Map pipelineParams = [:]) {
         // Call uploadPackages only if we are on the default branch,
         // if we have DEB/RPM packages to upload and if the user has set the pushArtifacts parameter to true
         // if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
-        if (debFiles && debFiles.size() > 0)
+        if (debFiles && debFiles.size() > 0) {
             echo "Found DEB packages, uploading..."
 
             def distribPom = readMavenPom file: 'workdir/distrib/pom.xml'

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -133,8 +133,8 @@ def call(Map pipelineParams = [:]) {
                 maven: pipelineParams.toolchain.maven,
                 options: [artifactsPublisher(disabled: true)]
             ) {
-                repoDistribution = sh(script: 'mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args="${kura.repo.distribution}" -q exec:exec --non-recursive', returnStdout: true).trim()
-                repoModule = sh(script: 'mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args="${kura.repo.module}" -q exec:exec --non-recursive', returnStdout: true).trim()
+                repoDistribution = sh(script: 'mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args=\'${kura.repo.distribution}\' -q exec:exec --non-recursive', returnStdout: true).trim()
+                repoModule = sh(script: 'mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args=\'${kura.repo.module}\' -q exec:exec --non-recursive', returnStdout: true).trim()
             }
 
             uploadPackages(repoDistribution, repoModule)

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -125,10 +125,9 @@ def call(Map pipelineParams = [:]) {
         if (debFiles && debFiles.size() > 0) {
             echo "Found DEB packages, uploading..."
 
-            def distribPom = readMavenPom file: 'workdir/distrib/pom.xml'
-
-            def repoDistribution = distribPom.properties['kura.repo.distribution']
-            def repoModule = distribPom.properties['kura.repo.module']
+            // Extract Maven properties using mvn help:evaluate
+            def repoDistribution = sh(script: "mvn -f workdir/distrib/pom.xml help:evaluate -Dexpression=kura.repo.distribution -q -DforceStdout", returnStdout: true).trim()
+            def repoModule = sh(script: "mvn -f workdir/distrib/pom.xml help:evaluate -Dexpression=kura.repo.module -q -DforceStdout", returnStdout: true).trim()
 
             uploadPackages(repoDistribution, repoModule)
         } else {
@@ -136,7 +135,6 @@ def call(Map pipelineParams = [:]) {
             Utils.markStageSkippedForConditional(STAGE_NAME)
         }
     }
-
 
     stage ("Archive artifacts") {
         dir("workdir") {

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -116,12 +116,13 @@ def call(Map pipelineParams = [:]) {
     }
 
     stage ("Deploy on Nexus") {
-        def debFiles = findFiles(glob: 'workdir/**/*.deb')
+        def debFilesOutput = sh(script: "find workdir -type f -name '*.deb'", returnStdout: true).trim()
+        def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
 
         // Call uploadPackages only if we are on the default branch,
         // if we have DEB/RPM packages to upload and if the user has set the pushArtifacts parameter to true
         // if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
-        if (debFiles) {
+        if (debFiles && debFiles.size() > 0)
             echo "Found DEB packages, uploading..."
 
             def distribPom = readMavenPom file: 'workdir/distrib/pom.xml'

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -125,17 +125,9 @@ def call(Map pipelineParams = [:]) {
         if (debFiles && debFiles.size() > 0) {
             echo "Found DEB packages, uploading..."
 
-            def repoDistribution
-            def repoModule
-
-            withMaven(
-                jdk: pipelineParams.toolchain.jdk,
-                maven: pipelineParams.toolchain.maven,
-                options: [artifactsPublisher(disabled: true)]
-            ) {
-                repoDistribution = sh(script: 'mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args=\'${kura.repo.distribution}\' -q exec:exec --non-recursive', returnStdout: true).trim()
-                repoModule = sh(script: 'mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args=\'${kura.repo.module}\' -q exec:exec --non-recursive', returnStdout: true).trim()
-            }
+            // FIXME read pom to extract distribution and module
+            def repoDistribution = "kura-6"
+            def repoModule = "base"
 
             uploadPackages(repoDistribution, repoModule)
         } else {

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -122,9 +122,28 @@ def call(Map pipelineParams = [:]) {
         if (true) {
             echo "Uploading DEB packages..."
 
-            // FIXME read pom to extract distribution and module
-            def repoDistribution = "kura-6"
-            def repoModule = "base"
+            def repoDistribution
+            def repoModule
+
+            withMaven(
+                jdk: pipelineParams.toolchain.jdk,
+                maven: pipelineParams.toolchain.maven,
+                options: [artifactsPublisher(disabled: true)]
+            ) {
+                repoDistribution = sh(script: '''
+                    mvn -f workdir/distrib/pom.xml \
+                        -Dexec.executable=echo \
+                        -Dexec.args="${kura.repo.distribution}" \
+                        -q exec:exec --non-recursive
+                ''', returnStdout: true).trim()
+
+                repoModule = sh(script: '''
+                    mvn -f workdir/distrib/pom.xml \
+                    -Dexec.executable=echo \
+                    -Dexec.args="${kura.repo.module}" \
+                    -q exec:exec --non-recursive
+                ''', returnStdout: true).trim()
+            }
 
             uploadPackages(repoDistribution, repoModule)
         } else {

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -115,15 +115,12 @@ def call(Map pipelineParams = [:]) {
         }
     }
 
-    stage ("Deploy on Nexus") {
-        def debFilesOutput = sh(script: "find workdir -type f -name '*.deb'", returnStdout: true).trim()
-        def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
-
+    stage ("Deploy on Nexus Repository") {
         // Call uploadPackages only if we are on the default branch,
         // if we have DEB packages to upload and if the user has set the pushArtifacts parameter to true
         // if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
-        if (debFiles && debFiles.size() > 0) {
-            echo "Found DEB packages, uploading..."
+        if (true) {
+            echo "Uploading DEB packages..."
 
             // FIXME read pom to extract distribution and module
             def repoDistribution = "kura-6"
@@ -131,7 +128,7 @@ def call(Map pipelineParams = [:]) {
 
             uploadPackages(repoDistribution, repoModule)
         } else {
-            echo "Skipping DEB upload"
+            echo "Skipping DEB packages upload."
             Utils.markStageSkippedForConditional(STAGE_NAME)
         }
     }

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -115,6 +115,26 @@ def call(Map pipelineParams = [:]) {
         }
     }
 
+    stage ("Deploy on Nexus") {
+        def debFiles = findFiles(glob: 'workdir/**/*.deb')
+
+        // Call uploadPackages only if we are on the default branch,
+        // if we have DEB/RPM packages to upload and if the user has set the pushArtifacts parameter to true
+        if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
+            echo "Found DEB packages, uploading..."
+
+            def distribPom = readMavenPom file: 'workdir/distrib/pom.xml'
+
+            def repoDistribution = distribPom.properties['kura.repo.distribution']
+            def repoModule = distribPom.properties['kura.repo.module']
+
+            uploadPackages(repoDistribution, repoModule)
+        } else {
+            echo "Skipping DEB/RPM upload"
+            Utils.markStageSkippedForConditional(STAGE_NAME)
+        }
+    }
+
 
     stage ("Archive artifacts") {
         dir("workdir") {

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -118,33 +118,14 @@ def call(Map pipelineParams = [:]) {
     stage ("Deploy on Nexus Repository") {
         // Call uploadPackages only if we are on the default branch,
         // if we have DEB packages to upload and if the user has set the pushArtifacts parameter to true
-        // if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
-        if (true) {
+        // if (env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
+        if (true) { // FIXME: For testing only
             echo "Uploading DEB packages..."
 
-            def repoDistribution
-            def repoModule
+            def distribPom = readMavenPom file: 'workdir/distrib/pom.xml'
 
-            // Retrieve distribution and module from distrib POM
-            withMaven(
-                jdk: pipelineParams.toolchain.jdk,
-                maven: pipelineParams.toolchain.maven,
-                options: [artifactsPublisher(disabled: true)]
-            ) {
-                repoDistribution = sh(script: """
-                    mvn -f workdir/distrib/pom.xml \
-                    help:evaluate \
-                    -Dexpression=kura.repo.distribution \
-                    -q -DforceStdout
-                """, returnStdout: true).trim().readLines()[-1]
-
-                repoModule = sh(script: """
-                    mvn -f workdir/distrib/pom.xml \
-                    help:evaluate \
-                    -Dexpression=kura.repo.module \
-                    -q -DforceStdout
-                """, returnStdout: true).trim().readLines()[-1]
-            }
+            def repoDistribution = distribPom.properties['kura.repo.distribution']
+            def repoModule = distribPom.properties['kura.repo.module']
 
             uploadPackages(repoDistribution, repoModule)
         } else {

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -120,18 +120,26 @@ def call(Map pipelineParams = [:]) {
         def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
 
         // Call uploadPackages only if we are on the default branch,
-        // if we have DEB/RPM packages to upload and if the user has set the pushArtifacts parameter to true
+        // if we have DEB packages to upload and if the user has set the pushArtifacts parameter to true
         // if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
         if (debFiles && debFiles.size() > 0) {
             echo "Found DEB packages, uploading..."
 
-            // Extract Maven properties using mvn help:evaluate
-            def repoDistribution = sh(script: "mvn -f workdir/distrib/pom.xml help:evaluate -Dexpression=kura.repo.distribution -q -DforceStdout", returnStdout: true).trim()
-            def repoModule = sh(script: "mvn -f workdir/distrib/pom.xml help:evaluate -Dexpression=kura.repo.module -q -DforceStdout", returnStdout: true).trim()
+            def repoDistribution
+            def repoModule
+
+            withMaven(
+                jdk: pipelineParams.toolchain.jdk,
+                maven: pipelineParams.toolchain.maven,
+                options: [artifactsPublisher(disabled: true)]
+            ) {
+                repoDistribution = sh(script: "mvn -f workdir/distrib/pom.xml help:evaluate -Dexpression=kura.repo.distribution -q -DforceStdout", returnStdout: true).trim()
+                repoModule = sh(script: "mvn -f workdir/distrib/pom.xml help:evaluate -Dexpression=kura.repo.module -q -DforceStdout", returnStdout: true).trim()
+            }
 
             uploadPackages(repoDistribution, repoModule)
         } else {
-            echo "Skipping DEB/RPM upload"
+            echo "Skipping DEB upload"
             Utils.markStageSkippedForConditional(STAGE_NAME)
         }
     }

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -135,14 +135,14 @@ def call(Map pipelineParams = [:]) {
                     help:evaluate \
                     -Dexpression=kura.repo.distribution \
                     -q -DforceStdout
-                """, returnStdout: true).trim()
+                """, returnStdout: true).trim().get(lines.size()-1)
 
                 repoModule = sh(script: """
                     mvn -f workdir/distrib/pom.xml \
                     help:evaluate \
                     -Dexpression=kura.repo.module \
                     -q -DforceStdout
-                """, returnStdout: true).trim()
+                """, returnStdout: true).trim().get(lines.size()-1)
             }
 
             uploadPackages(repoDistribution, repoModule)

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -133,14 +133,14 @@ def call(Map pipelineParams = [:]) {
                 repoDistribution = sh(script: '''
                     mvn -f workdir/distrib/pom.xml \
                         -Dexec.executable=echo \
-                        -Dexec.args="${kura.repo.distribution}" \
+                        -Dexec.args=\"${kura.repo.distribution}\" \
                         -q exec:exec --non-recursive
                 ''', returnStdout: true).trim()
 
                 repoModule = sh(script: '''
                     mvn -f workdir/distrib/pom.xml \
                     -Dexec.executable=echo \
-                    -Dexec.args="${kura.repo.module}" \
+                    -Dexec.args=\"${kura.repo.module}\" \
                     -q exec:exec --non-recursive
                 ''', returnStdout: true).trim()
             }

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -120,7 +120,8 @@ def call(Map pipelineParams = [:]) {
 
         // Call uploadPackages only if we are on the default branch,
         // if we have DEB/RPM packages to upload and if the user has set the pushArtifacts parameter to true
-        if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
+        // if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
+        if (debFiles) {
             echo "Found DEB packages, uploading..."
 
             def distribPom = readMavenPom file: 'workdir/distrib/pom.xml'

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -133,8 +133,8 @@ def call(Map pipelineParams = [:]) {
                 maven: pipelineParams.toolchain.maven,
                 options: [artifactsPublisher(disabled: true)]
             ) {
-                repoDistribution = sh(script: "mvn -f workdir/distrib/pom.xml help:evaluate -Dexpression=kura.repo.distribution -q -DforceStdout", returnStdout: true).trim()
-                repoModule = sh(script: "mvn -f workdir/distrib/pom.xml help:evaluate -Dexpression=kura.repo.module -q -DforceStdout", returnStdout: true).trim()
+                repoDistribution = sh(script: "mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args='${kura.repo.distribution}' -q exec:exec --non-recursive", returnStdout: true).trim()
+                repoModule = sh(script: "mvn -f workdir/distrib/pom.xml -Dexec.executable=echo -Dexec.args='${kura.repo.module}' -q exec:exec --non-recursive", returnStdout: true).trim()
             }
 
             uploadPackages(repoDistribution, repoModule)

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -125,6 +125,7 @@ def call(Map pipelineParams = [:]) {
             def repoDistribution
             def repoModule
 
+            // Retrieve distribution and module from distrib POM
             withMaven(
                 jdk: pipelineParams.toolchain.jdk,
                 maven: pipelineParams.toolchain.maven,

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -22,21 +22,6 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
         assert valid_modules.contains(repoModule)
     }
 
-    stage("Upload setup") {
-        server = Artifactory.server 'artifactory'
-
-        withCredentials([usernamePassword(credentialsId: 'artifactory-jenkins-esf-apitoken', passwordVariable: 'password', usernameVariable: 'username')]) {
-            server.username = "${username}"
-            server.password = "${password}"
-        }
-
-        dir("workdir") {
-            // Traceability info
-            GIT_SHA = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
-        }
-
-    }
-
     stage("Upload .deb packages to Artifactory") {
         def debFilesOutput = sh(script: "find workdir -type f -name '*.deb'", returnStdout: true).trim()
         def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -17,8 +17,11 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
     }
 
     stage("Upload .deb packages to Artifactory") {
-        def debFilesOutput = sh(script: "find workdir -type f -name '*.deb'", returnStdout: true).trim()
-        def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
+        def debFiles = findFiles(glob: 'workdir/**/*.deb')
+
+        if (debFiles.size() == 0) {
+            error("No .deb files found to upload")
+        }
 
         debFiles.each {
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
@@ -37,6 +40,5 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
         if (setupPromotion) {
             // TODO
         }
-
     }
 }

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -25,15 +25,21 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
 
         debFiles.each {
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
-                sh(
+                int status sh(
                     script: """
                         curl -u \"\$USERPASS\" \
+                        -w '%{http_code}' \
                         -H \"Content-Type: multipart/form-data\" \
                         --data-binary \"@./${it}\" \
-                        \"https://repo3.eclipse.org/repository/kura-apt-dev/\"
+                        \"https://repo3.eclipse.org/repository/kura-apt-dev/\" \
+                        -o /dev/null
                     """,
                     returnStatus: true
                 )
+            }
+
+            if (status != 200) {
+                error("Returned status code = $status")
             }
         }
 

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -26,11 +26,20 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
         def debFilesOutput = sh(script: "find workdir -type f -name '*.deb'", returnStdout: true).trim()
         def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
 
+        // Debug print all found .deb files
+        echo "Found .deb files:"
+        debFiles.each { echo it.toString() }
+        assert debFiles.size() > 0
+        echo "Total .deb files found: ${debFiles.size()}"
+
         debFiles.each {
             // Split file name to get the architecture
             def fileName = it.toString().split("/").last()
             def architecture = fileName.split("_").last().split("\\.")[0]
             assert VALID_DEB_ARCHITECTURES.contains(architecture)
+
+            // Print filename and architecture
+            echo "Uploading file: ${fileName} with architecture: ${architecture}"
 
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
                 sh '''

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -37,7 +37,7 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
                     returnStdout: true
                 ).trim()
 
-                if (status != "200") {
+                if (status != "201") {
                     error("Returned status code = $status")
                 }
             }

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -25,7 +25,7 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
 
         debFiles.each {
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
-                int status = sh(
+                def status = sh(
                     script: """
                         curl -u \"\$USERPASS\" \
                         -w '%{http_code}' \
@@ -34,11 +34,11 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
                         \"https://repo3.eclipse.org/repository/kura-apt-dev/\" \
                         -o /dev/null
                     """,
-                    returnStatus: true
+                    returnStdout: true
                 ).trim()
             }
 
-            if (status != 200) {
+            if (status != "200") {
                 error("Returned status code = $status")
             }
         }

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -38,7 +38,9 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
     }
 
     stage("Upload .deb packages to Artifactory") {
-        def debFiles = findFiles(glob: 'workdir/**/*.deb')
+        def debFilesOutput = sh(script: "find workdir -type f -name '*.deb'", returnStdout: true).trim()
+        def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
+
         debFiles.each {
             // Split file name to get the architecture
             def fileName = it.toString().split("/").last()

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -1,11 +1,5 @@
 def call(String repoDistribution, String repoModule, Boolean setupPromotion = false) {
-    def DEV_REPO = "kura-develop-deb"
-    def PROD_REPO = "kura-deb"
-    def DEB_COMPONENT = "main"
-    def VALID_DEB_ARCHITECTURES = ["amd64", "arm64", "all"]
-
     stage ("Upload packages parameters check") {
-
         echo "Distribution: ${repoDistribution}"
         echo "Module: ${repoModule}"
 
@@ -26,21 +20,7 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
         def debFilesOutput = sh(script: "find workdir -type f -name '*.deb'", returnStdout: true).trim()
         def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
 
-        // Debug print all found .deb files
-        echo "Found .deb files:"
-        debFiles.each { echo it.toString() }
-        assert debFiles.size() > 0
-        echo "Total .deb files found: ${debFiles.size()}"
-
         debFiles.each {
-            // Split file name to get the architecture
-            def fileName = it.toString().split("/").last()
-            def architecture = fileName.split("_").last().split("\\.")[0]
-            assert VALID_DEB_ARCHITECTURES.contains(architecture)
-
-            // Print filename and architecture
-            echo "Uploading file: ${fileName} with architecture: ${architecture}"
-
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
                 sh(
                     script: "curl -u \"\$USERPASS\" -H \"Content-Type: multipart/form-data\" --data-binary \"@./${it}\" \"https://repo3.eclipse.org/repository/kura-apt/\"",

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -16,7 +16,7 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
         assert valid_modules.contains(repoModule)
     }
 
-    stage("Upload .deb packages to Artifactory") {
+    stage("Upload .deb packages to Nexus") {
         def debFiles = findFiles(glob: 'workdir/**/*.deb')
 
         if (debFiles.size() == 0) {

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -42,9 +42,10 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
             echo "Uploading file: ${fileName} with architecture: ${architecture}"
 
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
-                sh '''
-                curl -u "$USERPASS" -H "Content-Type: multipart/form-data" --data-binary "@./${it}" "https://repo3.eclipse.org/repository/kura-apt/"
-                '''
+                sh(
+                    script: "curl -u \"\$USERPASS\" -H \"Content-Type: multipart/form-data\" --data-binary \"@./${it}\" \"https://repo3.eclipse.org/repository/kura-apt/\"",
+                    returnStatus: true
+                )
             }
         }
 

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -1,0 +1,60 @@
+def call(String repoDistribution, String repoModule, Boolean setupPromotion = false) {
+    def DEV_REPO = "kura-develop-deb"
+    def PROD_REPO = "kura-deb"
+    def DEB_COMPONENT = "main"
+    def VALID_DEB_ARCHITECTURES = ["amd64", "arm64", "all"]
+
+    stage ("Upload packages parameters check") {
+
+        echo "Distribution: ${repoDistribution}"
+        echo "Module: ${repoModule}"
+
+        // Check "distribution" parameter is set and valid
+        assert repoDistribution instanceof String
+        assert repoDistribution ==~ /kura-\d+/
+
+        // Check "module" parameter is set and valid
+        def valid_modules = [
+            "base"
+        ]
+
+        assert repoModule instanceof String
+        assert valid_modules.contains(repoModule)
+    }
+
+    stage("Upload setup") {
+        server = Artifactory.server 'artifactory'
+
+        withCredentials([usernamePassword(credentialsId: 'artifactory-jenkins-esf-apitoken', passwordVariable: 'password', usernameVariable: 'username')]) {
+            server.username = "${username}"
+            server.password = "${password}"
+        }
+
+        dir("workdir") {
+            // Traceability info
+            GIT_SHA = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+        }
+
+    }
+
+    stage("Upload .deb packages to Artifactory") {
+        def debFiles = findFiles(glob: 'workdir/**/*.deb')
+        debFiles.each {
+            // Split file name to get the architecture
+            def fileName = it.toString().split("/").last()
+            def architecture = fileName.split("_").last().split("\\.")[0]
+            assert VALID_DEB_ARCHITECTURES.contains(architecture)
+
+            withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
+                sh '''
+                curl -u "$USERPASS" -H "Content-Type: multipart/form-data" --data-binary "@./${it}" "https://repo3.eclipse.org/repository/kura-apt/"
+                '''
+            }
+        }
+
+        if (setupPromotion) {
+            // TODO
+        }
+
+    }
+}

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -36,10 +36,10 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
                     """,
                     returnStdout: true
                 ).trim()
-            }
 
-            if (status != "200") {
-                error("Returned status code = $status")
+                if (status != "200") {
+                    error("Returned status code = $status")
+                }
             }
         }
 

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -30,7 +30,7 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
                         curl -u \"\$USERPASS\" \
                         -H \"Content-Type: multipart/form-data\" \
                         --data-binary \"@./${it}\" \
-                        \"https://repo3.eclipse.org/repository/kura-apt/\"
+                        \"https://repo3.eclipse.org/repository/kura-apt-dev/\"
                     """,
                     returnStatus: true
                 )

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -23,7 +23,12 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
         debFiles.each {
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
                 sh(
-                    script: "curl -u \"\$USERPASS\" -H \"Content-Type: multipart/form-data\" --data-binary \"@./${it}\" \"https://repo3.eclipse.org/repository/kura-apt/\"",
+                    script: """
+                        curl -u \"\$USERPASS\" \
+                        -H \"Content-Type: multipart/form-data\" \
+                        --data-binary \"@./${it}\" \
+                        \"https://repo3.eclipse.org/repository/kura-apt/\"
+                    """,
                     returnStatus: true
                 )
             }

--- a/vars/uploadPackages.groovy
+++ b/vars/uploadPackages.groovy
@@ -25,7 +25,7 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
 
         debFiles.each {
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
-                int status sh(
+                int status = sh(
                     script: """
                         curl -u \"\$USERPASS\" \
                         -w '%{http_code}' \
@@ -35,7 +35,7 @@ def call(String repoDistribution, String repoModule, Boolean setupPromotion = fa
                         -o /dev/null
                     """,
                     returnStatus: true
-                )
+                ).trim()
             }
 
             if (status != 200) {


### PR DESCRIPTION
This PR adds the necessary step to perform the DEP packages upload on our recently introduced Kura APT repository. See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5706

Tested working on https://ci.eclipse.org/kura/job/kura-base/job/kura-metapackage/view/change-requests/job/PR-5/

Promotion setup will be introduced in a later PR.

Please note that `kura.repo.distribution` and `kura.repo.module` are not used at this point given the limited Nexus3 repository structure support.