### PR TITLE
fix: Updated sonar plugin info

### DIFF
--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -155,7 +155,7 @@ def call(Map pipelineParams = [:]) {
                             }
 
                             sh """
-                                mvn sonar:sonar \
+                                mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
                                     -Dmaven.test.failure.ignore=true \
                                     -Dsonar.organization=eclipse-kura \
                                     -Dsonar.host.url=${SONAR_HOST_URL} \


### PR DESCRIPTION
This pull request introduces a small update to the SonarQube invocation in the CI pipeline. The change ensures that the correct Maven plugin is explicitly referenced during the Sonar analysis step. 

* Updated the Maven command in the `call` method of `vars/continuousIntegrationPipeline.groovy` to use the fully qualified `sonar-maven-plugin` goal instead of the generic `sonar:sonar` goal.