### PR TITLE
fix: Added test.exclusions parameter and set default values

### DIFF
--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -31,7 +31,7 @@ def call(Map pipelineParams = [:]) {
     def defaultParameters = [
         toolchain: [ jdk: "temurin-jdk17-latest", maven: "apache-maven-3.9.6" ],
         buildType: "install",
-        sonar: [ enable: false, projectKey: null, tokenId: null, exclusions: null ],
+        sonar: [ enable: false, projectKey: null, tokenId: null, exclusions: "*.xml", testExclusions: "**/*.java,*.xml" ],
         pushArtifacts: true
     ]
     pipelineParams = defaultParameters << pipelineParams
@@ -71,6 +71,8 @@ def call(Map pipelineParams = [:]) {
             // Validate that exclusions don't contain potentially dangerous characters
             assert pipelineParams.sonar.exclusions instanceof String
             assert !pipelineParams.sonar.exclusions.matches(/.*[;&|`$(){}\[\]\"].*/) : "sonar.exclusions contains potentially dangerous characters"
+            assert pipelineParams.sonar.testExclusions instanceof String
+            assert !pipelineParams.sonar.testExclusions.matches(/.*[;&|`$(){}\[\]\"].*/) : "sonar.test.exclusions contains potentially dangerous characters"
         }
     }
 
@@ -163,7 +165,7 @@ def call(Map pipelineParams = [:]) {
                                     ${analysisParameters} \
                                     -Dsonar.core.codeCoveragePlugin=jacoco \
                                     -Dsonar.projectKey=${pipelineParams.sonar.projectKey} \
-                                    -Dsonar.exclusions=${pipelineParams.sonar.exclusions}
+                                    -Dsonar.exclusions=${pipelineParams.sonar.exclusions} -Dsonar.test.exclusions=${pipelineParams.sonar.testExclusions}
                             """
                         }
                     }

--- a/vars/continuousIntegrationPipeline.md
+++ b/vars/continuousIntegrationPipeline.md
@@ -25,7 +25,9 @@ node {
         sonar: [
           enable: true,
           projectKey: "eclipse-kura_kura-something",
-          tokenId: "sonarcloud-token-kura-something"
+          tokenId: "sonarcloud-token-kura-something",
+          exclusions: "*.xml",
+          testExclusions: "**/*.java,*.xml"
         ],
     )
 }

--- a/vars/continuousIntegrationPipeline.md
+++ b/vars/continuousIntegrationPipeline.md
@@ -9,7 +9,8 @@
      - `enable`: Enables/Disables the Sonar scan steps. Default value: `false`.
      - `tokenId`: Jenkins Credentials Id of the corresponding Sonar token used for authentication. It is provided by Eclipse Foundation devops when the Sonar project is created and its credentials are loaded in the Jenkins instance. **Must be set if Sonar scan is enabled**
      - `projectKey`: Sonar unique identifier for the project. Can be found on the SonarQube instance. **Must be set if Sonar scan is enabled**
-     - `exclusions`: Path to be excluded from Sonar analysis. **Must be set if Sonar scan is enabled**
+     - `exclusions`: Source path to be excluded from Sonar analysis. Default value: `*.xml`. **Must be set if Sonar scan is enabled**
+     - `testExclusions`: Test path to be excluded from Sonar analysis. Default value: `**/*.java,*.xml`. **Must be set if Sonar scan is enabled**
   - [Optional] `toolchain`: The toolchain to be used for the build. Default value: `[ jdk: "temurin-jdk17-latest", maven: "apache-maven-3.9.6" ]`. Available values:
      - **jdk**: `temurin-jdk17-latest`
      - **maven**: `apache-maven-3.9.6`
@@ -25,7 +26,6 @@ node {
           enable: true,
           projectKey: "eclipse-kura_kura-something",
           tokenId: "sonarcloud-token-kura-something"
-          exclusions: "tests/**/*.java"
         ],
     )
 }


### PR DESCRIPTION
This pull request updates the continuous integration pipeline to improve SonarQube analysis configuration, specifically by introducing a new parameter for test exclusions and enhancing validation and documentation. The main changes focus on allowing separate configuration of source and test file exclusions for Sonar analysis, improving security checks, and updating documentation.

**SonarQube Analysis Configuration:**

* Added a new `testExclusions` parameter to the Sonar configuration, allowing users to specify test paths to be excluded from Sonar analysis. The default value is set to `**/*.java,*.xml`. [[1]](diffhunk://#diff-e590fb0fb4ada0413e2aab6ac8d455e5895eaf81b3e64bbf72f7b292f9b176acL34-R34) [[2]](diffhunk://#diff-fa0e8642ab57e206f2373970ea5ef71211281b855aa34f091e2913bd4b51428aL12-R13)
* Updated the pipeline to pass both `sonar.exclusions` and `sonar.test.exclusions` to the SonarQube analysis step, ensuring both source and test exclusions are respected.

**Validation and Security:**

* Enhanced input validation to check that `testExclusions` is a string and does not contain potentially dangerous characters, similar to the existing check for `exclusions`.

**Documentation:**

* Updated the documentation in `continuousIntegrationPipeline.md` to describe the new `testExclusions` parameter, its default value, and its purpose.