### PR TITLE
fix: Updated again exclusions and test exclusions

### DIFF
--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -31,7 +31,7 @@ def call(Map pipelineParams = [:]) {
     def defaultParameters = [
         toolchain: [ jdk: "temurin-jdk17-latest", maven: "apache-maven-3.9.6" ],
         buildType: "install",
-        sonar: [ enable: false, projectKey: null, tokenId: null, exclusions: "*.xml", testExclusions: "**/*.java,*.xml" ],
+        sonar: [ enable: false, projectKey: null, tokenId: null, exclusions: "**/*.xml,**/*.yml", testExclusions: "**/*" ],
         pushArtifacts: true
     ]
     pipelineParams = defaultParameters << pipelineParams

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -31,7 +31,7 @@ def call(Map pipelineParams = [:]) {
     def defaultParameters = [
         toolchain: [ jdk: "temurin-jdk17-latest", maven: "apache-maven-3.9.6" ],
         buildType: "install",
-        sonar: [ enable: false, projectKey: null, tokenId: null, exclusions: "**/*.xml,**/*.yml", testExclusions: "**/*" ],
+        sonar: [ enable: false, projectKey: null, tokenId: null, exclusions: "tests/**/*,**/*.xml,**/*.yml", testExclusions: "**/*" ],
         pushArtifacts: true
     ]
     pipelineParams = defaultParameters << pipelineParams

--- a/vars/continuousIntegrationPipeline.md
+++ b/vars/continuousIntegrationPipeline.md
@@ -9,8 +9,8 @@
      - `enable`: Enables/Disables the Sonar scan steps. Default value: `false`.
      - `tokenId`: Jenkins Credentials Id of the corresponding Sonar token used for authentication. It is provided by Eclipse Foundation devops when the Sonar project is created and its credentials are loaded in the Jenkins instance. **Must be set if Sonar scan is enabled**
      - `projectKey`: Sonar unique identifier for the project. Can be found on the SonarQube instance. **Must be set if Sonar scan is enabled**
-     - `exclusions`: Source path to be excluded from Sonar analysis. Default value: `*.xml`. **Must be set if Sonar scan is enabled**
-     - `testExclusions`: Test path to be excluded from Sonar analysis. Default value: `**/*.java,*.xml`. **Must be set if Sonar scan is enabled**
+     - `exclusions`: Source path to be excluded from Sonar analysis. Default value: `**/*.xml,**/*.yml`. **Must be set if Sonar scan is enabled**
+     - `testExclusions`: Test path to be excluded from Sonar analysis. Default value: `**/*`. **Must be set if Sonar scan is enabled**
   - [Optional] `toolchain`: The toolchain to be used for the build. Default value: `[ jdk: "temurin-jdk17-latest", maven: "apache-maven-3.9.6" ]`. Available values:
      - **jdk**: `temurin-jdk17-latest`
      - **maven**: `apache-maven-3.9.6`
@@ -26,8 +26,8 @@ node {
           enable: true,
           projectKey: "eclipse-kura_kura-something",
           tokenId: "sonarcloud-token-kura-something",
-          exclusions: "*.xml",
-          testExclusions: "**/*.java,*.xml"
+          exclusions: "**/*.xml,**/*.yml",
+          testExclusions: "**/*"
         ],
     )
 }

--- a/vars/continuousIntegrationPipeline.md
+++ b/vars/continuousIntegrationPipeline.md
@@ -9,7 +9,7 @@
      - `enable`: Enables/Disables the Sonar scan steps. Default value: `false`.
      - `tokenId`: Jenkins Credentials Id of the corresponding Sonar token used for authentication. It is provided by Eclipse Foundation devops when the Sonar project is created and its credentials are loaded in the Jenkins instance. **Must be set if Sonar scan is enabled**
      - `projectKey`: Sonar unique identifier for the project. Can be found on the SonarQube instance. **Must be set if Sonar scan is enabled**
-     - `exclusions`: Source path to be excluded from Sonar analysis. Default value: `**/*.xml,**/*.yml`. **Must be set if Sonar scan is enabled**
+     - `exclusions`: Source path to be excluded from Sonar analysis. Default value: `tests/**/*,**/*.xml,**/*.yml`. **Must be set if Sonar scan is enabled**
      - `testExclusions`: Test path to be excluded from Sonar analysis. Default value: `**/*`. **Must be set if Sonar scan is enabled**
   - [Optional] `toolchain`: The toolchain to be used for the build. Default value: `[ jdk: "temurin-jdk17-latest", maven: "apache-maven-3.9.6" ]`. Available values:
      - **jdk**: `temurin-jdk17-latest`
@@ -26,7 +26,7 @@ node {
           enable: true,
           projectKey: "eclipse-kura_kura-something",
           tokenId: "sonarcloud-token-kura-something",
-          exclusions: "**/*.xml,**/*.yml",
+          exclusions: "tests/**/*,**/*.xml,**/*.yml",
           testExclusions: "**/*"
         ],
     )


### PR DESCRIPTION
This pull request updates the default SonarQube analysis configuration in the continuous integration pipeline to broaden the file exclusions for both source and test files. The documentation is also updated to reflect these new defaults.

**SonarQube Analysis Configuration Updates:**

* Broadened the default `exclusions` for SonarQube analysis to include both `**/*.xml` and `**/*.yml` files, ensuring these file types are excluded from source analysis by default. [[1]](diffhunk://#diff-e590fb0fb4ada0413e2aab6ac8d455e5895eaf81b3e64bbf72f7b292f9b176acL34-R34) [[2]](diffhunk://#diff-fa0e8642ab57e206f2373970ea5ef71211281b855aa34f091e2913bd4b51428aL12-R13) [[3]](diffhunk://#diff-fa0e8642ab57e206f2373970ea5ef71211281b855aa34f091e2913bd4b51428aL29-R30)
* Changed the default `testExclusions` for SonarQube to `**/*`, which means all files are excluded from test analysis unless otherwise specified. [[1]](diffhunk://#diff-e590fb0fb4ada0413e2aab6ac8d455e5895eaf81b3e64bbf72f7b292f9b176acL34-R34) [[2]](diffhunk://#diff-fa0e8642ab57e206f2373970ea5ef71211281b855aa34f091e2913bd4b51428aL12-R13) [[3]](diffhunk://#diff-fa0e8642ab57e206f2373970ea5ef71211281b855aa34f091e2913bd4b51428aL29-R30)

**Documentation Updates:**

* Updated `vars/continuousIntegrationPipeline.md` to document the new default values for `exclusions` and `testExclusions` and provided an updated example usage. [[1]](diffhunk://#diff-fa0e8642ab57e206f2373970ea5ef71211281b855aa34f091e2913bd4b51428aL12-R13) [[2]](diffhunk://#diff-fa0e8642ab57e206f2373970ea5ef71211281b855aa34f091e2913bd4b51428aL29-R30)