### PR TITLE
feat: Move to Java 21

### DIFF
--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -145,7 +145,7 @@ def call(Map pipelineParams = [:]) {
         if (pipelineParams.sonar.enable) {
             timeout(time: 2, unit: 'HOURS') {
                 dir("workdir") {
-                    withMaven(jdk: 'temurin-jdk21-latest', maven: 'apache-maven-3.9.9, options: [artifactsPublisher(disabled: true)]) {
+                    withMaven(jdk: 'temurin-jdk21-latest', maven: 'apache-maven-3.9.9', options: [artifactsPublisher(disabled: true)]) {
                         withSonarQubeEnv( credentialsId: pipelineParams.sonar.tokenId ) {
 
                             // Check if on primary branch

--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -29,7 +29,7 @@ def call(Map pipelineParams = [:]) {
 
     // Populate keys that are not set with default parameters
     def defaultParameters = [
-        toolchain: [ jdk: "temurin-jdk17-latest", maven: "apache-maven-3.9.6" ],
+        toolchain: [ jdk: "temurin-jdk21-latest", maven: "apache-maven-3.9.9" ],
         buildType: "install",
         sonar: [ enable: false, projectKey: null, tokenId: null, exclusions: "tests/**/*,**/*.xml,**/*.yml", testExclusions: "**/*" ],
         pushArtifacts: true
@@ -46,8 +46,8 @@ def call(Map pipelineParams = [:]) {
         assert pipelineParams.buildType.equals("install") || pipelineParams.buildType.equals("deploy")
 
         // Check toolchain option is set and valid
-        def valid_jdks = [ "temurin-jdk17-latest" ]
-        def valid_mavens = [ "apache-maven-3.9.6" ]
+        def valid_jdks = [ "temurin-jdk21-latest" ]
+        def valid_mavens = [ "apache-maven-3.9.9" ]
 
         assert pipelineParams.toolchain
         assert pipelineParams.toolchain.jdk instanceof String
@@ -145,7 +145,7 @@ def call(Map pipelineParams = [:]) {
         if (pipelineParams.sonar.enable) {
             timeout(time: 2, unit: 'HOURS') {
                 dir("workdir") {
-                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6', options: [artifactsPublisher(disabled: true)]) {
+                    withMaven(jdk: 'temurin-jdk21-latest', maven: 'apache-maven-3.9.9, options: [artifactsPublisher(disabled: true)]) {
                         withSonarQubeEnv( credentialsId: pipelineParams.sonar.tokenId ) {
 
                             // Check if on primary branch

--- a/vars/continuousIntegrationPipeline.md
+++ b/vars/continuousIntegrationPipeline.md
@@ -11,9 +11,9 @@
      - `projectKey`: Sonar unique identifier for the project. Can be found on the SonarQube instance. **Must be set if Sonar scan is enabled**
      - `exclusions`: Source path to be excluded from Sonar analysis. Default value: `tests/**/*,**/*.xml,**/*.yml`. **Must be set if Sonar scan is enabled**
      - `testExclusions`: Test path to be excluded from Sonar analysis. Default value: `**/*`. **Must be set if Sonar scan is enabled**
-  - [Optional] `toolchain`: The toolchain to be used for the build. Default value: `[ jdk: "temurin-jdk17-latest", maven: "apache-maven-3.9.6" ]`. Available values:
-     - **jdk**: `temurin-jdk17-latest`
-     - **maven**: `apache-maven-3.9.6`
+  - [Optional] `toolchain`: The toolchain to be used for the build. Default value: `[ jdk: "temurin-jdk21-latest", maven: "apache-maven-3.9.9" ]`. Available values:
+     - **jdk**: `temurin-jdk21-latest`
+     - **maven**: `apache-maven-3.9.9`
 
 ## Example caller pipeline script:
 


### PR DESCRIPTION
This pull request updates the default build toolchain for the continuous integration pipeline to use newer versions of JDK and Maven. All references, validations, and documentation have been updated to reflect these new defaults.

**Toolchain version upgrades:**

* Updated the default JDK from `temurin-jdk17-latest` to `temurin-jdk21-latest` and Maven from `apache-maven-3.9.6` to `apache-maven-3.9.9` in the pipeline parameters (`vars/continuousIntegrationPipeline.groovy`).
* Changed the list of valid JDK and Maven versions to only allow the new versions (`vars/continuousIntegrationPipeline.groovy`).
* Updated the SonarQube analysis step to use the new JDK and Maven versions (`vars/continuousIntegrationPipeline.groovy`).

**Documentation update:**

* Revised the documentation to reflect the new default and available toolchain versions (`vars/continuousIntegrationPipeline.md`).