### PR TITLE
ci: improve pipeline parameters defaults handling

### DIFF
--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -34,7 +34,10 @@ def call(Map pipelineParams = [:]) {
         sonar: [ enable: false, projectKey: null, tokenId: null, exclusions: "tests/**/*,**/*.xml,**/*.yml", testExclusions: "**/*" ],
         pushArtifacts: true
     ]
-    pipelineParams = defaultParameters << pipelineParams
+    pipelineParams = deepMerge(defaultParameters, pipelineParams)
+
+    // Pretty print the final pipeline parameters
+    echo "Pipeline parameters: ${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(pipelineParams))}"
 
     stage ("Pipeline parameters check") {
         // Print effective pipeline parameters for debugging

--- a/vars/deepMerge.groovy
+++ b/vars/deepMerge.groovy
@@ -1,0 +1,12 @@
+// Nested maps merger
+def call(Map defaults, Map overrides) {
+    def result = [:] + defaults
+    overrides.each { k, v ->
+        if (result[k] instanceof Map && v instanceof Map) {
+            result[k] = deepMerge(result[k] as Map, v as Map)
+        } else {
+            result[k] = v
+        }
+    }
+    return result
+}


### PR DESCRIPTION
The current main branch only implements shallow merging of the parameters provided by the user and the default parameters.

This means that, if a user calls the pipeline with:

```
continuousIntegrationPipeline( 
    toolchain: [ jdk: "temurin-jdk21-latest" ]
)
```

the `pipelineParams.toolchain.maven` variable will be set to `null` instead of falling back to the default.

This PR introduces a `deepMerge` function which handles the correct merging of the two maps and therefore results in a more logical behaviour and a better user experience.