### PR TITLE
ci: Pin sonar version

### DIFF
--- a/vars/continuousIntegrationPipeline.groovy
+++ b/vars/continuousIntegrationPipeline.groovy
@@ -160,7 +160,7 @@ def call(Map pipelineParams = [:]) {
                             }
 
                             sh """
-                                mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+                                mvn org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
                                     -Dmaven.test.failure.ignore=true \
                                     -Dsonar.organization=eclipse-kura \
                                     -Dsonar.host.url=${SONAR_HOST_URL} \


### PR DESCRIPTION
This pull request makes a minor update to the Sonar Maven plugin version used in the `continuousIntegrationPipeline.groovy` file. The change specifies an explicit version (`5.6.0.6792`) for the plugin to ensure consistent and predictable builds. The modification is needed for [1].

- Build tooling update:
  * Updated the Sonar Maven plugin invocation to use version `5.6.0.6792` instead of the default/latest version in the Maven command within `continuousIntegrationPipeline.groovy`.

[1] https://community.sonarsource.com/t/retiring-the-magic-sonar-sonar-shorthand-of-the-sonarscanner-for-maven/179815